### PR TITLE
chore: override serialize-javascript to ^7.0.6 to resolve Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@playwright/test": "^1.44.0",
         "chai": "^4.3.7",
         "mocha": "^10.2.0",
-        "serialize-javascript": "^7.0.5"
+        "serialize-javascript": "^7.0.6"
       }
     },
     "node_modules/@playwright/test": {
@@ -712,16 +712,6 @@
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/mocha/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -861,16 +851,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -893,27 +873,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/serialize-javascript": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "mocha": "^10.2.0",
     "chai": "^4.3.7",
     "@playwright/test": "^1.44.0",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.6"
   },
-  "postinstall": "npx playwright install --with-deps"
+  "postinstall": "npx playwright install --with-deps",
+  "overrides": {
+    "serialize-javascript": "^7.0.6"
+  }
 }


### PR DESCRIPTION
Adds an npm override to force serialize-javascript@^7.0.6 and updates package-lock.json. Unit tests pass locally. This addresses Dependabot alerts originating from nested mocha dependency.